### PR TITLE
Add sessionid cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,19 +25,23 @@ module.exports = {
     else {
 
 
-      const data = await fetch(instagramGraphUrl)
+      const data = await fetch(instagramGraphUrl, {
+        headers: {
+          cookie: `sessionid=${inputs.sessionID}`
+        }
+      })
         .then(res => {
           // ensure that we are only acting on JSON responses
           if(res.headers.get('content-type').includes('application/json')){
             return res.json();
           } else {
-            return null;
+            return res.text();
           }
         });
 
       // If we didn't receive JSON, fail the plugin but not the build
-      if(!data){
-        utils.build.failPlugin(`The Instagram feed did not return JSON data.\nProceeding with the build without the data from the plugin.`);
+      if(!data?.graphql?.user?.edge_owner_to_timeline_media?.edges){
+        utils.build.failPlugin(`The Instagram feed did not return expected data.\nProceeding with the build without the data from the plugin.`);
         return;
       }
 
@@ -69,7 +73,11 @@ module.exports = {
         console.log('Restored from cache:', chalk.green(localImageURL));
       } else {
         // if the image is not cached, fetch and cache it.
-        await fetch(sourceImageURL)
+        await fetch(sourceImageURL, {
+          headers: {
+            cookie: `sessionid=${inputs.sessionID}`
+          }
+        })
           .then(async res => {
               const dest = fs.createWriteStream(localImageURL);
               res.body.pipe(dest);
@@ -81,5 +89,3 @@ module.exports = {
 
   }
 }
-
-


### PR DESCRIPTION
Un-authenticated users no longer have access to a user's Instagram feed. Consequently if you don't want to use the full-blown API, you have to grab the `sessionid` cookie for an authenticated user and use that instead. This PR pulls that `sessionid` value from the inputs and uses it when fetching the feed and the images.